### PR TITLE
Update fork

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/danielsaidi/KeyboardKit.git",
         "state": {
           "branch": "master",
-          "revision": "910d2594bd194a8dff0033f5f6e73cc9e73ea129",
+          "revision": "458e5c91e2dc8983370b077acda6861a2ae7eac1",
           "version": null
         }
       },

--- a/README.md
+++ b/README.md
@@ -78,3 +78,6 @@ KeyboardKitSwiftUI is available under the MIT license. See LICENSE file for more
 
 [KeyboardKit]: https://github.com/danielsaidi/KeyboardKit
 [Post]: https://danielsaidi.com/blog/2021/01/15/removing-uikit-support-in-keyboardkit
+
+[Anomaly]: http://anomaly.net.au
+[Milo]: https://www.milocreative.com

--- a/Sources/KeyboardKitSwiftUI/Callouts/InputCalloutContext.swift
+++ b/Sources/KeyboardKitSwiftUI/Callouts/InputCalloutContext.swift
@@ -1,5 +1,5 @@
 //
-//  SecondaryInputCalloutContext.swift
+//  InputCalloutContext.swift
 //  KeyboardKit
 //
 //  Created by Daniel Saidi on 2021-01-06.

--- a/Sources/KeyboardKitSwiftUI/Callouts/SecondaryInputCalloutContext.swift
+++ b/Sources/KeyboardKitSwiftUI/Callouts/SecondaryInputCalloutContext.swift
@@ -39,8 +39,8 @@ open class SecondaryInputCalloutContext: ObservableObject {
     
     // MARK: - Dependencies
     
-    private let actionProvider: SecondaryCalloutActionProvider
-    private let context: KeyboardContext
+    public var actionProvider: SecondaryCalloutActionProvider
+    public var context: KeyboardContext
     
     
     // MARK: - Properties

--- a/Sources/KeyboardKitSwiftUI/Context/ObservableKeyboardContext.swift
+++ b/Sources/KeyboardKitSwiftUI/Context/ObservableKeyboardContext.swift
@@ -20,7 +20,6 @@ import UIKit
  */
 public class ObservableKeyboardContext: KeyboardContext, ObservableObject {
     
-    
     public init(from context: KeyboardContext) {
         controller = context.controller
         
@@ -29,7 +28,6 @@ public class ObservableKeyboardContext: KeyboardContext, ObservableObject {
         keyboardBehavior = context.keyboardBehavior
         keyboardInputSetProvider = context.keyboardInputSetProvider
         keyboardLayoutProvider = context.keyboardLayoutProvider
-        secondaryCalloutActionProvider = context.secondaryCalloutActionProvider
         
         device = context.device
         deviceOrientation = context.deviceOrientation
@@ -44,9 +42,7 @@ public class ObservableKeyboardContext: KeyboardContext, ObservableObject {
         textInputMode = context.textInputMode
         traitCollection = context.traitCollection
         
-        SecondaryInputCalloutContext.shared = SecondaryInputCalloutContext(
-            actionProvider: context.secondaryCalloutActionProvider,
-            context: self)
+        SecondaryInputCalloutContext.shared = SecondaryInputCalloutContext.shared ?? SecondaryInputCalloutContext(actionProvider: StandardSecondaryCalloutActionProvider(), context: self)
     }
     
     unowned public var controller: KeyboardInputViewController
@@ -60,14 +56,6 @@ public class ObservableKeyboardContext: KeyboardContext, ObservableObject {
     @Published public var keyboardInputSetProvider: KeyboardInputSetProvider
     @Published public var keyboardLayoutProvider: KeyboardLayoutProvider
     @Published public var keyboardType: KeyboardType
-    @Published public var secondaryCalloutActionProvider: SecondaryCalloutActionProvider {
-        didSet {
-            SecondaryInputCalloutContext.shared = SecondaryInputCalloutContext(
-                actionProvider: self.secondaryCalloutActionProvider,
-                context: self)
-        }
-    }
-    
     @Published public var deviceOrientation: UIInterfaceOrientation
     @Published public var hasDictationKey: Bool
     @Published public var hasFullAccess: Bool

--- a/Sources/KeyboardKitSwiftUI/Extensions/View+Button.swift
+++ b/Sources/KeyboardKitSwiftUI/Extensions/View+Button.swift
@@ -35,6 +35,12 @@ public extension View {
     
     /**
      Apply a standard button font.
+     
+     `TODO` The appearance provider is currently in the main
+     repo, which targets iOS 11. We can therefore not have a
+     collection of SwiftUI-specific appearance properties in
+     it, which means that the light font currently has to be
+     added like below. I'm looking for a solution.
      */
     func standardButtonFont(for action: KeyboardAction, context: KeyboardContext) -> some View {
         let hasImage = action.standardButtonImage(for: context) != nil

--- a/Sources/KeyboardKitSwiftUI/System/SystemKeyboardButtonContent.swift
+++ b/Sources/KeyboardKitSwiftUI/System/SystemKeyboardButtonContent.swift
@@ -36,10 +36,10 @@ public struct SystemKeyboardButtonContent: View {
     public var body: some View {
         if action == .nextKeyboard {
             AnyView(NextKeyboardButton(controller: context.controller))
-        } else if let text = buttonText {
-            AnyView(textView(for: text))
         } else if let image = buttonImage {
             AnyView(image)
+        } else if let text = buttonText {
+            AnyView(textView(for: text))
         } else {
             AnyView(Text(""))
         }
@@ -48,12 +48,12 @@ public struct SystemKeyboardButtonContent: View {
 
 private extension SystemKeyboardButtonContent {
     
-    var buttonText: String? {
-        text ?? appearance.text(for: action)
-    }
-    
     var buttonImage: Image? {
         image ?? action.standardButtonImage(for: context)
+    }
+    
+    var buttonText: String? {
+        text ?? appearance.text(for: action)
     }
     
     func textView(for text: String) -> some View {


### PR DESCRIPTION
* Add todo

* Make econdary action context's provider and context settable

* Remove secondary callout action provider from the keyboard context

* Make SystemKeyboardButtonContent prio image before text

Co-authored-by: Daniel Saidi <daniel.saidi@gmail.com>