### PR TITLE
Possible font weight solution

### DIFF
--- a/Sources/KeyboardKitSwiftUI/Extensions/Font+Weight.swift
+++ b/Sources/KeyboardKitSwiftUI/Extensions/Font+Weight.swift
@@ -1,0 +1,37 @@
+//
+//  Font+Weight.swift
+//  
+//
+//  Created by Brennan Drew on 1/16/21.
+//
+
+import UIKit
+import SwiftUI
+
+public extension Font {
+    func weight(_ uiFontWeight: UIFont.Weight?) -> Font {
+        if let weight = uiFontWeight?.fontWeight() {
+            return self.weight(weight)
+        } else {
+            return self
+        }
+    }
+}
+
+private extension UIFont.Weight {
+    func fontWeight() -> Font.Weight {
+        switch self {
+        case .black: return .black
+        case .bold: return .bold
+        case .heavy: return .heavy
+        case .light: return .light
+        case .medium: return .medium
+        case .regular: return .regular
+        case .semibold: return .semibold
+        case .thin: return .thin
+        case .ultraLight: return .ultraLight
+        
+        default: return .regular
+        }
+    }
+}

--- a/Sources/KeyboardKitSwiftUI/Extensions/View+Button.swift
+++ b/Sources/KeyboardKitSwiftUI/Extensions/View+Button.swift
@@ -43,9 +43,9 @@ public extension View {
      added like below. I'm looking for a solution.
      */
     func standardButtonFont(for action: KeyboardAction, context: KeyboardContext) -> some View {
-        let hasImage = action.standardButtonImage(for: context) != nil
         let rawFont = Font(context.keyboardAppearanceProvider.font(for: action))
-        return hasImage ? font(rawFont.weight(.light)) : font(rawFont)
+        let fontWeight = context.keyboardAppearanceProvider.fontWeight(for: action, context: context)
+        return font(rawFont.weight(fontWeight))
     }
     
     /**

--- a/Sources/KeyboardKitSwiftUI/System/SystemKeyboardButtonContent.swift
+++ b/Sources/KeyboardKitSwiftUI/System/SystemKeyboardButtonContent.swift
@@ -60,6 +60,6 @@ private extension SystemKeyboardButtonContent {
         Text(text)
             .minimumScaleFactor(0.1)
             .lineLimit(1)
-            .offset(y: -2)
+            .offset(y: action.isInputAction ? -2 : 0)
     }
 }


### PR DESCRIPTION
By adding fontWeight to `KeyboardAppearanceProvider`, the default behavior of font weights can be set along with the current text and font options.  The change in `View+Button.swift` is an example of how this font weight could be used. 

There is a corresponding pull request in the main repo.