### PR TITLE
Add protocol KeyboardDimensions and put width logic into SystemKeyboardDimensions

### DIFF
--- a/Sources/KeyboardKitSwiftUI/System/KeyboardDimensions.swift
+++ b/Sources/KeyboardKitSwiftUI/System/KeyboardDimensions.swift
@@ -1,0 +1,24 @@
+//
+//  KeyboardDimensions.swift
+//  KeyboardKit
+//
+//  Created by Brennan Drew on 2021-01-19.
+//
+
+import CoreGraphics
+import Combine
+import SwiftUI
+import KeyboardKit
+
+/**
+ This struct specifies dimensions for a `SystemKeyboard`.
+ */
+public protocol KeyboardDimensions {
+    
+    var buttonHeight: CGFloat { get }
+    var buttonInsets: EdgeInsets { get }
+    var longButtonWidth: CGFloat { get }
+    var shortButtonWidth: CGFloat { get }
+    
+    func width(for action: KeyboardAction, keyboardWidth: CGFloat, context: KeyboardContext) -> CGFloat?
+}

--- a/Sources/KeyboardKitSwiftUI/System/SystemKeyboard.swift
+++ b/Sources/KeyboardKitSwiftUI/System/SystemKeyboard.swift
@@ -21,7 +21,7 @@ public struct SystemKeyboard: View {
     
     public init(
         layout: KeyboardLayout,
-        dimensions: SystemKeyboardDimensions = SystemKeyboardDimensions(),
+        dimensions: KeyboardDimensions = SystemKeyboardDimensions(),
         buttonBuilder: @escaping ButtonBuilder = Self.standardButtonBuilder) {
         self.rows = layout.actionRows
         self.dimensions = dimensions
@@ -29,7 +29,7 @@ public struct SystemKeyboard: View {
     }
     
     private let buttonBuilder: ButtonBuilder
-    private let dimensions: SystemKeyboardDimensions
+    private let dimensions: KeyboardDimensions
     private let rows: KeyboardActionRows
     
     @State private var size: CGSize = .zero

--- a/Sources/KeyboardKitSwiftUI/System/SystemKeyboardButtonRowItem.swift
+++ b/Sources/KeyboardKitSwiftUI/System/SystemKeyboardButtonRowItem.swift
@@ -24,7 +24,7 @@ public struct SystemKeyboardButtonRowItem<Content: View>: View {
     public init(
         action: KeyboardAction,
         buttonContent: Content,
-        dimensions: SystemKeyboardDimensions = SystemKeyboardDimensions(),
+        dimensions: KeyboardDimensions = SystemKeyboardDimensions(),
         keyboardSize: CGSize) {
         self.action = action
         self.buttonContent = buttonContent
@@ -34,7 +34,7 @@ public struct SystemKeyboardButtonRowItem<Content: View>: View {
     
     private let action: KeyboardAction
     private let buttonContent: Content
-    private let dimensions: SystemKeyboardDimensions
+    private let dimensions: KeyboardDimensions
     private let keyboardSize: CGSize
     
     @EnvironmentObject var context: ObservableKeyboardContext
@@ -43,7 +43,7 @@ public struct SystemKeyboardButtonRowItem<Content: View>: View {
         buttonContent
             .frame(maxWidth: .infinity)
             .frame(height: dimensions.buttonHeight - dimensions.buttonInsets.top - dimensions.buttonInsets.bottom)
-            .applyWidth(for: action, with: context.keyboardType, from: dimensions, keyboardWidth: keyboardSize.width)
+            .applyWidth(for: action, from: dimensions, keyboardWidth: keyboardSize.width, context: context)
             .standardButtonStyle(for: action, context: context)
             .padding(dimensions.buttonInsets)
             .frame(height: dimensions.buttonHeight)
@@ -57,59 +57,13 @@ private extension View {
     @ViewBuilder
     func applyWidth(
         for action: KeyboardAction,
-        with keyboardType: KeyboardType,
-        from dimensions: SystemKeyboardDimensions,
-        keyboardWidth: CGFloat) -> some View {
-        if let width = width(for: action, with: keyboardType, from: dimensions, keyboardWidth: keyboardWidth) {
+        from dimensions: KeyboardDimensions,
+        keyboardWidth: CGFloat,
+        context: KeyboardContext) -> some View {
+        if let width = dimensions.width(for: action, keyboardWidth: keyboardWidth, context: context) {
             self.frame(width: width)
         } else {
             self
-        }
-    }
-    
-    func width(
-        for action: KeyboardAction,
-        with keyboardType: KeyboardType,
-        from dimensions: SystemKeyboardDimensions,
-        keyboardWidth: CGFloat) -> CGFloat? {
-        switch action {
-        case .shift, .backspace: return dimensions.shortButtonWidth
-        case .space: return keyboardWidth * 0.5
-        case .keyboardType(let type): return widthKeyboardType(switchingTo: type, current: keyboardType, from: dimensions)
-        default: return nil
-        }
-    }
-    
-    func widthKeyboardType(switchingTo: KeyboardType, current: KeyboardType, from dimensions: SystemKeyboardDimensions) -> CGFloat? {
-        switch switchingTo {
-        case .numeric:
-            switch current {
-            case .symbolic: return dimensions.shortButtonWidth
-            default: return nil
-            }
-        case .symbolic:
-            switch current {
-            case .numeric: return dimensions.shortButtonWidth
-            default: return nil
-            }
-        default: return nil
-        }
-    }
-    
-    func width(for keyboardType: KeyboardType, from dimensions: SystemKeyboardDimensions) -> CGFloat? {
-        switch keyboardType {
-        case .numeric, .alphabetic: return dimensions.longButtonWidth
-        default: return dimensions.shortButtonWidth
-        }
-    }
-}
-
-private extension KeyboardAction {
-    
-    var isShift: Bool {
-        switch self {
-        case .shift: return true
-        default: return false
         }
     }
 }

--- a/Sources/KeyboardKitSwiftUI/System/SystemKeyboardDimensions.swift
+++ b/Sources/KeyboardKitSwiftUI/System/SystemKeyboardDimensions.swift
@@ -9,11 +9,12 @@
 import CoreGraphics
 import Combine
 import SwiftUI
+import KeyboardKit
 
 /**
  This struct specifies dimensions for a `SystemKeyboard`.
  */
-public struct SystemKeyboardDimensions {
+public struct SystemKeyboardDimensions: KeyboardDimensions {
     
     public init(
         buttonHeight: CGFloat = .standardKeyboardRowHeight(),
@@ -30,4 +31,39 @@ public struct SystemKeyboardDimensions {
     public let buttonInsets: EdgeInsets
     public let longButtonWidth: CGFloat
     public let shortButtonWidth: CGFloat
+    
+    
+    public func width(
+        for action: KeyboardAction,
+        keyboardWidth: CGFloat,
+        context: KeyboardContext) -> CGFloat? {
+        switch action {
+        case .shift, .backspace: return shortButtonWidth
+        case .space: return keyboardWidth * 0.5
+        case .nextKeyboard: return shortButtonWidth
+        case .keyboardType(let type): return widthKeyboardType(switchingTo: type, context: context)
+        default: return nil
+        }
+    }
+    
+    func widthKeyboardType(switchingTo: KeyboardType, context: KeyboardContext) -> CGFloat? {
+        let currentType = context.keyboardType
+        let alphWidth: CGFloat? = context.needsInputModeSwitchKey ? shortButtonWidth : nil
+        
+        switch switchingTo {
+        case .numeric:
+            switch currentType {
+            case .symbolic: return shortButtonWidth
+            case .alphabetic: return alphWidth
+            default: return nil
+            }
+        case .symbolic:
+            switch currentType {
+            case .numeric: return shortButtonWidth
+            default: return nil
+            }
+        case .alphabetic: return alphWidth
+        default: return nil
+        }
+    }
 }


### PR DESCRIPTION
The previous quick fix PR I added was too inflexible.  The idea in this PR is to pull out all of the width logic, which was previously inaccessible in a private `View` extension, into SystemKeyboardDimensions.  Additionally, I added some logic to fix button sizes when on screens that require a input switcher button.  A bigger change is adding a KeyboardDimensions protocol allows you to pass your own KeyboardDimensions struct into default components.

I still realize that most of this is going to be replaced relatively soon, but it will still be nice to be able to have more control of some of this logic in the meantime.